### PR TITLE
Remove unneeded instance variables, renamed 'Renameable' to 'Comparable'

### DIFF
--- a/lib/comparable.rb
+++ b/lib/comparable.rb
@@ -1,4 +1,4 @@
-module Renameable
+module Comparable
 
   def season_verification(game, season)
     game.game_id.start_with?(season[0..3])

--- a/lib/game_statistics.rb
+++ b/lib/game_statistics.rb
@@ -1,8 +1,8 @@
 require_relative './stat_tracker'
-require_relative './renameable'
+require_relative './comparable'
 
 class GameStatistics
-include Renameable
+include Comparable
   attr_reader :games, :teams, :game_teams
 
   def initialize(games, teams, game_teams)

--- a/lib/game_teams.rb
+++ b/lib/game_teams.rb
@@ -3,37 +3,24 @@ class GameTeams
               :team_id,
               :hoa,
               :result,
-              :settled_in,
               :head_coach,
               :goals,
               :shots,
-              :tackles,
-              :pim,
-              :power_play_opportunities,
-              :power_play_goals,
-              :face_off_win_percentage,
-              :giveaways,
-              :takeaways
+              :tackles
 
   def initialize(hash)
     @game_id                  = hash[:game_id]
     @team_id                  = hash[:team_id]
     @hoa                      = hash[:hoa]
     @result                   = hash[:result]
-    @settled_in               = hash[:settled_in]
     @head_coach               = hash[:head_coach]
     @goals                    = hash[:goals]
     @shots                    = hash[:shots]
     @tackles                  = hash[:tackles]
-    @pim                      = hash[:pim]
-    @power_play_opportunities = hash[:powerplayopportunities]
-    @power_play_goals         = hash[:powerplaygoals]
-    @face_off_win_percentage  = hash[:faceoffwinpercentage]
-    @giveaways                = hash[:giveaways]
-    @takeaways                = hash[:takeaways]
+
   end
 
   def win?
     @result == 'WIN'
-  end 
+  end
 end

--- a/lib/season_statistics.rb
+++ b/lib/season_statistics.rb
@@ -1,8 +1,8 @@
 require_relative './stat_tracker'
-require_relative './renameable'
+require_relative './comparable'
 
 class SeasonStatistics
-  include Renameable
+  include Comparable
   attr_reader :games,
               :teams,
               :game_teams
@@ -38,7 +38,6 @@ class SeasonStatistics
   def total_games_by_coach(season)
     games_by_coach = Hash.new(0)
     @game_teams.each do |game|
-      require "pry"; binding.pry
       if season_verification(game, season)
         games_by_coach[game.head_coach] += 1
       end

--- a/lib/team_statistics.rb
+++ b/lib/team_statistics.rb
@@ -1,7 +1,7 @@
-require_relative './renameable'
+require_relative './comparable'
 
 class TeamStatistics
-  include Renameable
+  include Comparable
   attr_reader :games, :teams, :game_teams
 
   def initialize (games, teams, game_teams)

--- a/spec/comparable_spec.rb
+++ b/spec/comparable_spec.rb
@@ -4,7 +4,7 @@ require 'simplecov'
 require 'CSV'
 
 SimpleCov.start
-RSpec.describe Renameable do
+RSpec.describe Comparable do
   before :each do
     game_path = './data/games_test.csv'
     team_path = './data/teams.csv'
@@ -42,7 +42,5 @@ RSpec.describe Renameable do
 
   it 'returns count_equal_to' do
     expect(@game_stats.count_equal_to(@game_stats.games, :home_goals, :away_goals)).to eq(3)
-
-
   end
 end

--- a/spec/game_teams_spec.rb
+++ b/spec/game_teams_spec.rb
@@ -11,17 +11,10 @@ RSpec.describe GameTeams do
       team_id:"3",
       hoa:"away",
       result:"LOSS",
-      settled_in:"OT",
       head_coach:"John Tortorella",
       goals:"2",
       shots:"8",
-      tackles:"44",
-      pim:"8",
-      powerplayopportunities:"3",
-      powerplaygoals:"0",
-      faceoffwinpercentage:"44.8",
-      giveaways:"17",
-      takeaways:"7"
+      tackles:"44"
     }
     game_teams = GameTeams.new(hash)
 
@@ -30,17 +23,10 @@ RSpec.describe GameTeams do
     expect(game_teams.team_id).to eq("3")
     expect(game_teams.hoa).to eq("away")
     expect(game_teams.result).to eq("LOSS")
-    expect(game_teams.settled_in).to eq("OT")
     expect(game_teams.head_coach).to eq("John Tortorella")
     expect(game_teams.goals).to eq("2")
     expect(game_teams.shots).to eq("8")
     expect(game_teams.tackles).to eq("44")
-    expect(game_teams.pim).to eq("8")
-    expect(game_teams.power_play_opportunities).to eq("3")
-    expect(game_teams.power_play_goals).to eq("0")
-    expect(game_teams.face_off_win_percentage).to eq("44.8")
-    expect(game_teams.giveaways).to eq("17")
-    expect(game_teams.takeaways).to eq("7")
   end
 
   it 'returns win result' do


### PR DESCRIPTION
Cleaned up unused instance variables and changed all uses of 'Renameable' in all files to the renamed 'Comparable'
